### PR TITLE
ExcelReferenceEx.RefersTo fix

### DIFF
--- a/ExcelDna.Utilities/ExcelReferenceEx.cs
+++ b/ExcelDna.Utilities/ExcelReferenceEx.cs
@@ -151,7 +151,7 @@ namespace ExcelDna.Utilities
 
         public static string RefersTo(this ExcelReference range)
         {
-            object result = XlCall.Excel(XlCall.xlfGetCell, 6);
+            object result = XlCall.Excel(XlCall.xlfGetCell, 6, range);
             return (string)result;
         }
 


### PR DESCRIPTION
Fixed ExcelReferenceEx.RefersTo to use the ExcelReference passed in instead of current selection
